### PR TITLE
Added an alias for people who use the alternate syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ RSpec.describe SomeService do
 
     # expect_to_run / expect_not_to_run / expect_to_not_run
     # expect_to_execute
-    # expect_to_delay_run / expect_to_not_run_delayed
+    # expect_to_delay_run / expect_not_to_run_delayed / expect_to_not_run_delayed
     # expect_to_delay_execute
   end
 end

--- a/lib/active_interaction/extras/rspec.rb
+++ b/lib/active_interaction/extras/rspec.rb
@@ -67,6 +67,8 @@ module ActiveInteraction::Extras::Rspec
     expect(klass).to_not receive(:delay).with(*with)
   end
 
+  alias expect_to_not_run_delayed expect_not_to_run_delayed
+
   # see expect_to_run
   #
   # additional params


### PR DESCRIPTION
I usually have a hard time looking for the opposite of `expect_to_run_delayed` and apparently it's because it is using `expect_to_not_run_delayed`. I can see that `expect_to_run` has `expect_not_to_run` AND `expect_to_not_run` so I figured to add the alternate syntax as well. Hope this is okay! 🤞 