### PR TITLE
Fixed order of alias

### DIFF
--- a/lib/active_interaction/extras/rspec.rb
+++ b/lib/active_interaction/extras/rspec.rb
@@ -67,7 +67,7 @@ module ActiveInteraction::Extras::Rspec
     expect(klass).to_not receive(:delay).with(*with)
   end
 
-  alias expect_to_not_run_delayed expect_not_to_run_delayed
+  alias expect_not_to_run_delayed expect_to_not_run_delayed
 
   # see expect_to_run
   #


### PR DESCRIPTION
I messed up the ordering of the alias. TBH I thought this would have been covered by a spec but apparently `expect_not_to_run_delayed` and `expect_to_not_run_delayed` don't have coverage. Additionally I copied this off the other method: `expect_not_to_run`, which was unfortunate as the "original" method is the opposite `expect_to_not_run_delayed` (see screenshot).

![image](https://user-images.githubusercontent.com/46548/103494384-969bdc80-4e71-11eb-99db-c51823422fcb.png)

In any case, I fixed it now and hopefully I get to add a spec for it soon. 🤞 