### PR TITLE
Fix run_in_transaction! in rails >= 6.0

### DIFF
--- a/lib/active_interaction/extras/transaction.rb
+++ b/lib/active_interaction/extras/transaction.rb
@@ -7,7 +7,7 @@ module ActiveInteraction::Extras::Transaction
   included do
     class_attribute :run_in_transaction_options
     set_callback :execute, :around, ->(_interaction, block) {
-      ActiveRecord::Base.transaction(run_in_transaction_options) do
+      ActiveRecord::Base.transaction(**run_in_transaction_options) do
         block.call
       end
     }, if: :run_in_transaction_options


### PR DESCRIPTION
Hi @antulik

First of all thank you for this gem! I use it on a fairly young rails 6.1 application. After upgrading to active_interaction-extras 1.0 I am getting an error in interactions that use `run_in_interaction!`. 

I tried to write a spec for this but it looks like the specs for transactions are skipped and I couldn't find a good way to test this.

I don't have a way to test this change in a rails version < 6.0. I believe the change is backwards compatible but no promises ;)

---

It seems `ActiveRecord::Base.transaction` has changed signature between
rails 5.2 and rails 6.0. In my rails 6 application making this change
fixes this crash:

```
Failure/Error: subject(:interaction) { described_class.run(inputs) }

     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # /Users/jgrau/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/activerecord-6.1.3.2/lib/active_record/transactions.rb:208:in `transaction'
     # /Users/jgrau/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/active_interaction-extras-1.0.0/lib/active_interaction/extras/transaction.rb:10:in `block (2 levels) in <module:Transaction>'
     # /Users/jgrau/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/activesupport-6.1.3.2/lib/active_support/callbacks.rb:126:in `instance_exec'
```

See the difference in `transaction` signatures:

5.2: https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/transactions.rb#L211
6.0: https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/transactions.rb#L211