### PR TITLE
Return model_fields values from given model

### DIFF
--- a/active_interaction-extras.gemspec
+++ b/active_interaction-extras.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "active_interaction", ">= 4.0.2"
+  spec.add_dependency "active_interaction", ">= 4.0.2", "<5"
   spec.add_dependency "activemodel", ">= 6.0"
   spec.add_dependency "activesupport", ">= 6.0"
 

--- a/lib/active_interaction/extras/model_fields.rb
+++ b/lib/active_interaction/extras/model_fields.rb
@@ -72,6 +72,8 @@ module ActiveInteraction::Extras::ModelFields
   # overwritten to pre-populate model fields
   def populate_filters_and_inputs(_inputs)
     super.tap do
+      @_interaction_inputs = ActiveInteraction::Inputs.new(@_interaction_inputs.dup)
+
       self.class.filters.each do |name, filter|
         next if given?(name)
 
@@ -79,8 +81,11 @@ module ActiveInteraction::Extras::ModelFields
         next if model_field.nil?
 
         value = public_send(model_field)&.public_send(name)
+        @_interaction_inputs[name] = value
         public_send("#{name}=", filter.clean(value, self))
       end
+
+      @_interaction_inputs.freeze
     end
   end
 

--- a/spec/lib/model_fields_spec.rb
+++ b/spec/lib/model_fields_spec.rb
@@ -15,34 +15,30 @@ RSpec.describe ActiveInteraction::Extras::ModelFields do
     end
 
     describe '#model_fields' do
-      context 'new object' do
-        it 'prepopulates fields' do
-          model = double('Model', date_field: Date.today)
-          result = test_form_class.new(model: model)
+      subject(:model_fields) { interaction.model_fields(:model) }
 
-          expect(result.date_field).to eq Date.today
+      let(:interaction) { test_form_class.new(**interaction_args) }
+      let(:interaction_args) { {model: model} }
+      let(:model) { double('Model', date_field: Date.today) }
+
+      it 'returns values from given model' do
+        expect(model_fields).to eq(date_field: Date.today)
+      end
+
+      context 'with nil value for model field argument' do
+        let(:interaction_args) { {model: model, date_field: nil} }
+
+        it 'sets model field value to nil' do
+          expect(model_fields).to eq(date_field: nil)
         end
       end
 
-      it 'prepopulates model fields' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model)
+      context 'with empty string value for model field argument' do
+        let(:interaction_args) { {model: model, date_field: ''} }
 
-        expect(result).to eq Date.today
-      end
-
-      it 'sets to nil' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model, date_field: nil)
-
-        expect(result).to be_nil
-      end
-
-      it 'sets empty string to nil' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model, date_field: '')
-
-        expect(result).to be_nil
+        it 'sets model field value to nil' do
+          expect(model_fields).to eq(date_field: nil)
+        end
       end
     end
 


### PR DESCRIPTION
Since `Extras` v1.0.2 the `ActiveInteraction::Base#populate_filters_and_inputs`
method is overridden but it is only assigning values from the received model
to an interaction's filters and not the `inputs` data structure as the method name suggests.
This impacts the values returned by `ActiveInteraction::Extras::ModelFields#model_fields`
since it returns sliced model attributes from `inputs`.