### PR TITLE
Ensure StrongParams#initialize raises ArgumentError

### DIFF
--- a/lib/active_interaction/extras/strong_params.rb
+++ b/lib/active_interaction/extras/strong_params.rb
@@ -3,7 +3,10 @@ module ActiveInteraction::Extras::StrongParams
 
   def initialize(inputs = {})
     # TODO: whitelist :params and :form_params, so they could not be used as filters
-    return super if self.class.filters.key?(:params) || self.class.filters.key?(:form_params)
+    return super if
+      self.class.filters.key?(:params) ||
+      self.class.filters.key?(:form_params) ||
+      !%i[fetch key? merge].all? { |m| inputs.respond_to? m }
 
     if inputs.key?(:params) && inputs.key?(:form_params)
       raise ArgumentError, 'Both options :params and :form_params are given. ' \

--- a/spec/lib/strong_params_spec.rb
+++ b/spec/lib/strong_params_spec.rb
@@ -102,4 +102,10 @@ RSpec.describe ActiveInteraction::Extras::StrongParams do
       expect(ParentScope::TestService.run!(params)).to eq(a: 1, b: 2)
     end
   end
+
+  context 'with invalid inputs object type' do
+    it 'raises ArgumentError' do
+      expect { klass.run(Object.new) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
Delegate argument error handling to `ActiveInteraction::Base#initialize` for non hash-like `inputs` argument.